### PR TITLE
fixed the link between product details and products page

### DIFF
--- a/controllers/productCtrl.js
+++ b/controllers/productCtrl.js
@@ -19,7 +19,7 @@ module.exports.getProdById = (req, res, next) => {
     }
    })
    .then( (product) => {
-     res.render('products', { product });
+     res.render('product-details', { product });
    })
 }
 


### PR DESCRIPTION
## Branch Name
db-product-details-fix

## Database Name
bangazonmarket

## Status
**Ready**

## Description
Swapped product details page for a better version.

## Resolves Issue Number


## Impacted Files in Application
productCtrl

## Testing
1. ```sequelize db:migrate:undo:all``` [to drop all the tables]
2. ```sequelize db:migrate``` [to build database]
3. ```sequelize db:seed:all``` [to seed data to tables]
4. Got to the Product Categories page and click on a product
5. You should see an improved product details page.